### PR TITLE
NativeAPI: Expose `TypeTreeGenerator_getMonoBehaviorDefinitions`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,8 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Built binaries
+*.dll
+*.so 
+*.dylib

--- a/TypeTreeGeneratorAPI/NativeAPI.cs
+++ b/TypeTreeGeneratorAPI/NativeAPI.cs
@@ -192,8 +192,8 @@ namespace TypeTreeGeneratorAPI
                 {
                     string module = typeNames[i].Module.Name;
                     string fullName = typeNames[i].FullName;
-                    Marshal.WriteIntPtr(arrayPtr, (i * 2) * Marshal.SizeOf<IntPtr>(), Marshal.StringToCoTaskMemAnsi(module));
-                    Marshal.WriteIntPtr(arrayPtr, (i * 2 + 1) * Marshal.SizeOf<IntPtr>(), Marshal.StringToCoTaskMemAnsi(fullName));
+                    Marshal.WriteIntPtr(arrayPtr, (i * 2) * Marshal.SizeOf<IntPtr>(), Marshal.StringToCoTaskMemUTF8(module));
+                    Marshal.WriteIntPtr(arrayPtr, (i * 2 + 1) * Marshal.SizeOf<IntPtr>(), Marshal.StringToCoTaskMemUTF8(fullName));
                 }
             
                 Marshal.WriteIntPtr(arrAddrPtr, arrayPtr);

--- a/bindings/python/TypeTreeGeneratorAPI/TypeTreeGenerator.py
+++ b/bindings/python/TypeTreeGeneratorAPI/TypeTreeGenerator.py
@@ -159,10 +159,13 @@ class TypeTreeGenerator:
             ctypes.byref(names_ptr),
             ctypes.byref(names_cnt),
         ), "failed to get module exports"
-        names_array = ctypes.cast(
+        ptr_array = ctypes.cast(
             names_ptr, ctypes.POINTER(ctypes.c_char_p * names_cnt.value)
-        ).contents
-        names = [name.decode("ascii") for name in names_array]
+        )
+        names = [name.decode("utf-8") for name in ptr_array.contents]
+        for ptr in ptr_array:
+            ptr = ctypes.cast(ptr, ctypes.c_void_p).value
+            DLL.FreeCoTaskMem(ptr)
         DLL.FreeCoTaskMem(names_ptr)
         return [(module, fullname) for module, fullname in zip(names[::2], names[1::2])]
 


### PR DESCRIPTION
This PR exposes `GetMonoBehaviourDefinitions` to the Python side of things 

Can be accessed through `TypeTreeGenerator.get_monobehavior_definitions` where it returns a list of `(module name, class full path)` which can be then used as arguments to e.g. `get_nodes`